### PR TITLE
fix: pass epochScale to formatDate in Conversations page

### DIFF
--- a/web/src/pages/Conversations.tsx
+++ b/web/src/pages/Conversations.tsx
@@ -148,7 +148,7 @@ export function Conversations() {
                         {chat.message_count}
                       </td>
                       <td style={{ textAlign: 'right', padding: '6px 14px', color: 'var(--text-secondary)' }}>
-                        {chat.last_message_at ? formatDate(chat.last_message_at) : '\u2014'}
+                        {chat.last_message_at ? formatDate(chat.last_message_at, 1000) : '\u2014'}
                       </td>
                     </tr>
                     {isExpanded && (
@@ -184,7 +184,7 @@ export function Conversations() {
                                         Agent
                                       </span>
                                     )}
-                                    <span style={{ marginLeft: 'auto' }}>{formatDate(msg.timestamp)}</span>
+                                    <span style={{ marginLeft: 'auto' }}>{formatDate(msg.timestamp, 1000)}</span>
                                   </div>
                                   <pre style={{
                                     margin: 0,


### PR DESCRIPTION
## Description

`formatDate()` in `Conversations.tsx` is called without the `epochScale` parameter. Since `tg_chats.last_message_at` and `tg_messages.timestamp` are stored as Unix seconds, but `formatDate()` defaults to `epochScale=1` (treating input as milliseconds), all dates render as January 1970.

`Memory.tsx` already passes `1000` correctly — this fix applies the same pattern to both `formatDate()` calls in `Conversations.tsx`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

> Note: `typecheck` has pre-existing failures unrelated to this change (e.g. CronSDK types, api/server.ts date types). The fix itself is a two-character change — adding `, 1000` to two existing `formatDate()` calls.

## Related Issues

None