### PR TITLE
fix(ci): Buildx setup so the release Docker job can export gha cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Hotfix for the failed v0.9.0 release run.

`publish-docker` failed with `Cache export is not supported for the docker driver`: the 0.9.0 cycle added `cache-from/cache-to: type=gha` to the build-push step without a `docker/setup-buildx-action` step, so the default `docker` driver can't export the GHA cache. Adds `docker/setup-buildx-action@v3` (creates a `docker-container` driver) before login.

Note: the `publish-npm` failure in the same run is a separate, credential-side issue (E404 on PUT to an existing public package = invalid/expired `NPM_TOKEN`), not addressed by this code change.