### PR TITLE
fix(docker): runtime build toolchain for better-sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,18 @@ FROM node:20-slim
 
 WORKDIR /app
 
-# Copy package files and install production deps only
+# Copy package files and install production deps only.
+# better-sqlite3 has no usable prebuilt for this image and compiles from source, so the
+# build toolchain is installed, used, then purged in the same layer to keep the image slim.
 COPY package.json package-lock.json ./
-RUN npm pkg delete scripts.prepare \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && npm pkg delete scripts.prepare \
     && npm ci --omit=dev \
-    && npm cache clean --force
+    && npm cache clean --force \
+    && apt-get purge -y python3 make g++ \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy pre-built native module from build stage
 COPY --from=build /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node


### PR DESCRIPTION
Second hotfix for the v0.9.0 release Docker image.

After the Buildx fix (#24) let the Docker build actually run, `publish-docker` failed at the runtime stage: `npm ci --omit=dev` rebuilds better-sqlite3, which bumped 12.8.0 -> 12.10.0 this cycle and no longer resolves a usable prebuilt for `node:20-slim`, so it falls back to node-gyp and fails (the runtime stage had no build tools). Dockerfile was unchanged since v0.8.6 — the dependency bump exposed the latent gap.

Fix: install python3/make/g++ in the runtime stage, run `npm ci --omit=dev`, then purge them in the same layer (image stays slim). `--ignore-scripts` was rejected: 8 prod deps (sharp, onnxruntime-node, ...) have native install scripts that must run.

Verified 100% locally before pushing:
- `docker build .` succeeds (both stages)
- `docker run --help` runs the CLI
- better-sqlite3 + sharp + onnxruntime-node all load at runtime

npm teleton@0.9.0 is already published; re-tagging after merge only rebuilds the Docker image (publish-npm / publish-sdk / create-release skip via their idempotency checks).